### PR TITLE
Refactor sf_wifi: generic driver, runtime credentials, reconnect backoff

### DIFF
--- a/components/sf_wifi/CMakeLists.txt
+++ b/components/sf_wifi/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
     SRCS "sf_wifi.c"
     INCLUDE_DIRS "." "../../include"
-    REQUIRES esp_wifi log)
+    REQUIRES esp_wifi esp_netif esp_event esp_timer log)

--- a/components/sf_wifi/sf_wifi.c
+++ b/components/sf_wifi/sf_wifi.c
@@ -1,140 +1,330 @@
-#include "esp_wifi.h"
-#include "esp_log.h"
+#include <string.h>
+#include <inttypes.h>
 
-#include "sf_wifi.h"
+#include "esp_wifi.h"
+#include "esp_netif.h"
+#include "esp_event.h"
+#include "esp_timer.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 
-static int s_retry_num = 0;
-static const char* TAG = "SF_WIFI";
+#include "sf_wifi.h"
 
-/* FreeRTOS event group to signal when we are connected*/
-static EventGroupHandle_t s_wifi_event_group;
+#define SF_WIFI_MAXIMUM_RETRY           5
+#define SF_WIFI_RECONNECT_DELAY_INIT_MS 1000
+#define SF_WIFI_RECONNECT_DELAY_MAX_MS  30000
 
-/* The event group allows multiple bits for each event, but we only care about two events:
- * - we are connected to the AP with an IP
- * - we failed to connect after the maximum amount of retries */
-#define WIFI_CONNECTED_BIT BIT0
-#define WIFI_FAIL_BIT      BIT1
+#define WIFI_CONNECTED_BIT  BIT0
+#define WIFI_AUTH_FAIL_BIT  BIT1
+#define WIFI_NO_AP_BIT      BIT2
 
+ESP_EVENT_DEFINE_BASE(SF_WIFI_EVENT);
 
-static void event_handler(void* arg, esp_event_base_t event_base,
-                                int32_t event_id, void* event_data)
+static const char *TAG = "SF_WIFI";
+
+static bool                  s_driver_initialized     = false; /* TODO(commit5): remove once sf_wifi_init() is gone */
+static volatile bool         s_initial_connect_phase  = false;
+static uint32_t              s_reconnect_delay_ms     = SF_WIFI_RECONNECT_DELAY_INIT_MS;
+
+static EventGroupHandle_t    s_wifi_event_group       = NULL;
+static esp_netif_t          *s_ap_netif               = NULL;
+static esp_timer_handle_t    s_reconnect_timer        = NULL;
+static int                   s_retry_num              = 0;
+
+/* ------------------------------------------------------------------ */
+
+static void reconnect_timer_cb(void *arg)
 {
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+    ESP_LOGI(TAG, "Reconnect attempt");
+    esp_wifi_connect();
+}
+
+static void handle_sta_start(void)
+{
+    s_retry_num = 0;
+    /* Only initiate connect when sf_wifi_connect() started the session.
+     * In AP-only or APSTA provisioning mode this is suppressed. */
+    if (s_initial_connect_phase) {
         esp_wifi_connect();
-    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-        if (s_retry_num < SF_WIFI_CONFIG_MAXIMUM_RETRY) {
-            esp_wifi_connect();
-            s_retry_num++;
-            ESP_LOGI(TAG, "Connect to the AP fail, retry to connect to the AP ...");
-        } 
-        else {
-            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
-        }
-    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-        ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
-        ESP_LOGI(TAG, "Connected to AP, Device IP:" IPSTR, IP2STR(&event->ip_info.ip));
-        s_retry_num = 0;
-        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
     }
 }
 
-sf_err_t sf_wifi_init(void)
+static void handle_sta_disconnected(wifi_event_sta_disconnected_t *disc)
 {
-    esp_err_t status = ESP_FAIL;
+    bool auth_fail = (disc->reason == WIFI_REASON_AUTH_FAIL);
 
-    ESP_LOGI(TAG, "sf initializing wifi ...");
-
-    s_wifi_event_group = xEventGroupCreate();
-
-    status = esp_netif_init();
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "esp_netif_init status: %d", status);
-
-    esp_event_loop_create_default();
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "esp_event_loop_create_default status: %d", status);
-
-    esp_netif_create_default_wifi_sta();
-
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    esp_wifi_init(&cfg);
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "esp_wifi_init status: %d", status);
-
-    esp_event_handler_instance_t instance_any_id;
-    esp_event_handler_instance_t instance_got_ip;
-    status = esp_event_handler_instance_register(WIFI_EVENT,
-                                                        ESP_EVENT_ANY_ID,
-                                                        &event_handler,
-                                                        NULL,
-                                                        &instance_any_id);
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "instance_any_id - Register event handler instance status: %d", status);
-
-    status = esp_event_handler_instance_register(IP_EVENT,
-                                                        IP_EVENT_STA_GOT_IP,
-                                                        &event_handler,
-                                                        NULL,
-                                                        &instance_got_ip);
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "instance_got_ip - Register event handler instance status: %d", status);
-
-    wifi_config_t wifi_config = {
-        .sta = {
-            .ssid = CONFIG_SIM_FLOW_WIFI_SSID,
-            .password = CONFIG_SIM_FLOW_WIFI_PASSWORD,
-            /* Authmode threshold resets to WPA2 as default if password matches WPA2 standards (password len => 8).
-             * If you want to connect the device to deprecated WEP/WPA networks, Please set the threshold value
-             * to WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK and set the password with length and format matching to
-             * WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK standards.
-             */
-            .threshold.authmode = WIFI_AUTH_WPA2_PSK,
-            .sae_pwe_h2e = WPA3_SAE_PWE_BOTH,
-            .listen_interval = 3,
-        },
-    };
-    status = esp_wifi_set_mode(WIFI_MODE_STA);
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "Set mode status: %d", status);
-
-    status = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
-    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL, "Set config status: %d", status);
-
-    status = esp_wifi_start() ;
-    SF_CHECK_ERR_GOTO(ESP_LOGI, TAG, status, FAIL, "Start wifi status: %d", status);
-
-    status = esp_wifi_set_ps(WIFI_PS_MAX_MODEM);
-    SF_CHECK_ERR_GOTO(ESP_LOGI, TAG, status, FAIL, "Set WiFi power save status: %d", status);
-
-        /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
-     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
-    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
-        WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-        pdFALSE,
-        pdFALSE,
-        portMAX_DELAY);
-    
-    if (bits & WIFI_FAIL_BIT)
-    {
-        ESP_LOGI(TAG, "Failed to connect to SSID:%s", wifi_config.sta.ssid);
-        goto FAIL;
-    } else if (bits & WIFI_CONNECTED_BIT) {
-        ESP_LOGI(TAG, "Connected to AP SSID:%s", wifi_config.sta.ssid);
+    if (s_initial_connect_phase) {
+        if (auth_fail) {
+            /* Definitive credential failure — 0 retries, unblock sf_wifi_connect(). */
+            ESP_LOGW(TAG, "Auth fail (reason %d)", disc->reason);
+            xEventGroupSetBits(s_wifi_event_group, WIFI_AUTH_FAIL_BIT);
+        } else if (s_retry_num < SF_WIFI_MAXIMUM_RETRY) {
+            esp_wifi_connect();
+            s_retry_num++;
+            ESP_LOGI(TAG, "Retry %d/%d (reason %d)",
+                     s_retry_num, SF_WIFI_MAXIMUM_RETRY, disc->reason);
+        } else {
+            ESP_LOGW(TAG, "Connect retries exhausted (reason %d)", disc->reason);
+            xEventGroupSetBits(s_wifi_event_group, WIFI_NO_AP_BIT);
+            /* Hand off to perpetual self-heal — once s_initial_connect_phase is
+             * cleared the timer's esp_wifi_connect() lands in the perpetual branch. */
+            esp_timer_start_once(s_reconnect_timer,
+                                 (uint64_t)s_reconnect_delay_ms * 1000ULL);
+        }
     } else {
-        ESP_LOGE(TAG, "UNEXPECTED EVENT");
-        goto FAIL;
+        if (auth_fail) {
+            ESP_LOGW(TAG, "Auth fail on reconnect (reason %d)", disc->reason);
+            if (esp_event_post(SF_WIFI_EVENT, SF_WIFI_EVENT_AUTH_FAIL,
+                               NULL, 0, pdMS_TO_TICKS(100)) != ESP_OK) {
+                ESP_LOGW(TAG, "post AUTH_FAIL failed");
+            }
+        } else {
+            ESP_LOGI(TAG, "Disconnected, reconnect in %"PRIu32" ms (reason %d)",
+                     s_reconnect_delay_ms, disc->reason);
+            if (esp_event_post(SF_WIFI_EVENT, SF_WIFI_EVENT_DISCONNECTED,
+                               NULL, 0, pdMS_TO_TICKS(100)) != ESP_OK) {
+                ESP_LOGW(TAG, "post DISCONNECTED failed");
+            }
+            if (esp_timer_start_once(s_reconnect_timer,
+                                     (uint64_t)s_reconnect_delay_ms * 1000ULL) == ESP_OK) {
+                s_reconnect_delay_ms = (s_reconnect_delay_ms < SF_WIFI_RECONNECT_DELAY_MAX_MS)
+                                     ? s_reconnect_delay_ms * 2
+                                     : SF_WIFI_RECONNECT_DELAY_MAX_MS;
+            }
+        }
+    }
+}
+
+static void handle_sta_got_ip(ip_event_got_ip_t *event)
+{
+    ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+    s_reconnect_delay_ms = SF_WIFI_RECONNECT_DELAY_INIT_MS;
+    xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    if (!s_initial_connect_phase) {
+        if (esp_event_post(SF_WIFI_EVENT, SF_WIFI_EVENT_CONNECTED,
+                           NULL, 0, pdMS_TO_TICKS(100)) != ESP_OK) {
+            ESP_LOGW(TAG, "post CONNECTED failed");
+        }
+    }
+}
+
+/* Note: if sf_wifi_connect() is called while WiFi is already started,
+ * STA_START does not fire and s_retry_num is not reset; the counter carries
+ * over, which is acceptable since that path is not exercised in the current
+ * provisioning design. */
+static void event_handler(void *arg, esp_event_base_t event_base,
+                           int32_t event_id, void *event_data)
+{
+    if (event_base == WIFI_EVENT) {
+        switch (event_id) {
+            case WIFI_EVENT_STA_START:
+                handle_sta_start();
+                break;
+            case WIFI_EVENT_STA_DISCONNECTED:
+                SF_CHECK_NULL_RETURN(ESP_LOGE, TAG, event_data, "STA_DISCONNECTED with NULL data");
+                handle_sta_disconnected((wifi_event_sta_disconnected_t *)event_data);
+                break;
+            default:
+                break;
+        }
+    } else if (event_base == IP_EVENT) {
+        switch (event_id) {
+            case IP_EVENT_STA_GOT_IP:
+                SF_CHECK_NULL_RETURN(ESP_LOGE, TAG, event_data, "STA_GOT_IP with NULL data");
+                handle_sta_got_ip((ip_event_got_ip_t *)event_data);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+
+sf_err_t sf_wifi_driver_init(void)
+{
+    if (s_driver_initialized) {
+        return SF_OK;
     }
 
-    ESP_LOGI(TAG, "wifi_init_sta finished succesfully.");
+    esp_err_t status;
+
+    s_wifi_event_group = xEventGroupCreate();
+    SF_CHECK_NULL_GOTO(ESP_LOGE, TAG, s_wifi_event_group, FAIL,
+                       "Failed to create WiFi event group");
+
+    /* Both calls return ESP_ERR_INVALID_STATE if already initialised by
+     * another component — treat that as success, not an error. */
+    status = esp_netif_init();
+    SF_CHECK_EXPR_GOTO(ESP_LOGE, TAG,
+                       (status != ESP_OK && status != ESP_ERR_INVALID_STATE),
+                       FAIL, "esp_netif_init failed: %d", status);
+
+    status = esp_event_loop_create_default();
+    SF_CHECK_EXPR_GOTO(ESP_LOGE, TAG,
+                       (status != ESP_OK && status != ESP_ERR_INVALID_STATE),
+                       FAIL, "esp_event_loop_create_default failed: %d", status);
+
+    esp_netif_t *sta_netif = esp_netif_create_default_wifi_sta();
+    SF_CHECK_NULL_GOTO(ESP_LOGE, TAG, sta_netif, FAIL,
+                       "Failed to create default WiFi STA netif");
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    status = esp_wifi_init(&cfg);
+    SF_CHECK_ERR_GOTO(ESP_LOGV, TAG, status, FAIL,
+                      "esp_wifi_init status: %d", status);
+
+    status = esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                  &event_handler, NULL, NULL);
+    SF_CHECK_ERR_GOTO(ESP_LOGE, TAG, status, FAIL,
+                      "Register WIFI_EVENT handler: %d", status);
+
+    status = esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                                  &event_handler, NULL, NULL);
+    SF_CHECK_ERR_GOTO(ESP_LOGE, TAG, status, FAIL,
+                      "Register IP_EVENT handler: %d", status);
+
+    /* TODO(#65): replace with sf_timer once it supports task-context callbacks,
+     * one-shot mode, and multiple independent instances. */
+    esp_timer_create_args_t timer_args = {
+        .callback = reconnect_timer_cb,
+        .name     = "wifi_reconnect",
+    };
+    status = esp_timer_create(&timer_args, &s_reconnect_timer);
+    SF_CHECK_ERR_GOTO(ESP_LOGE, TAG, status, FAIL,
+                      "Create reconnect timer: %d", status);
+
+    s_driver_initialized = true;
+    ESP_LOGI(TAG, "Driver initialized.");
+
     return SF_OK;
 
 FAIL:
-    ESP_LOGI(TAG, "wifi_init_sta failed.");
     return SF_FAIL;
+}
+
+sf_wifi_conn_status_t sf_wifi_connect(const char *ssid, const char *password)
+{
+    ESP_LOGI(TAG, "Connecting to SSID: %s", ssid);
+
+    s_initial_connect_phase = true;
+
+    xEventGroupClearBits(s_wifi_event_group,
+                         WIFI_CONNECTED_BIT | WIFI_AUTH_FAIL_BIT | WIFI_NO_AP_BIT);
+
+    /* ssid/password are uint8_t[] arrays — cannot be set from a runtime
+     * const char * in a struct initializer; strlcpy is required. */
+    wifi_config_t wifi_config = {
+        .sta = {
+            .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+            .sae_pwe_h2e        = WPA3_SAE_PWE_BOTH,
+            .listen_interval    = 3,
+        },
+    };
+    strlcpy((char *)wifi_config.sta.ssid,     ssid,     sizeof(wifi_config.sta.ssid));
+    strlcpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password));
+
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
+
+    esp_err_t start_err = esp_wifi_start();
+    if (start_err == ESP_ERR_WIFI_CONN) {
+        /* Already started — WIFI_EVENT_STA_START won't fire, connect directly. */
+        esp_wifi_connect();
+    } else if (start_err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_wifi_start failed: %d", start_err);
+        s_initial_connect_phase = false;
+        return SF_WIFI_CONN_FAIL;
+    }
+
+    esp_wifi_set_ps(WIFI_PS_MAX_MODEM);
+
+    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+                                            WIFI_CONNECTED_BIT | WIFI_AUTH_FAIL_BIT | WIFI_NO_AP_BIT,
+                                            pdFALSE, pdFALSE, portMAX_DELAY);
+
+    /* Clear flag BEFORE returning so the perpetual handler activates cleanly. */
+    s_initial_connect_phase = false;
+
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "Connected to SSID: %s", ssid);
+        return SF_WIFI_CONN_OK;
+    } else if (bits & WIFI_AUTH_FAIL_BIT) {
+        ESP_LOGW(TAG, "Auth fail for SSID: %s", ssid);
+        return SF_WIFI_CONN_AUTH_FAIL;
+    }
+
+    ESP_LOGW(TAG, "Failed to connect to SSID: %s", ssid);
+    return SF_WIFI_CONN_NO_AP;
+}
+
+sf_err_t sf_wifi_ap_start(const char *ssid)
+{
+    if (!s_ap_netif) {
+        s_ap_netif = esp_netif_create_default_wifi_ap();
+        SF_CHECK_NULL_GOTO(ESP_LOGE, TAG, s_ap_netif, FAIL,
+                           "Failed to create AP netif");
+    }
+
+    wifi_config_t ap_config = {
+        .ap = {
+            .channel        = 1,
+            .authmode       = WIFI_AUTH_OPEN,
+            .max_connection = 4,
+        },
+    };
+    strlcpy((char *)ap_config.ap.ssid, ssid, sizeof(ap_config.ap.ssid));
+    ap_config.ap.ssid_len = (uint8_t)strlen(ssid);
+
+    esp_err_t status;
+    /* Use APSTA if STA is already running, AP-only otherwise. */
+    wifi_mode_t mode = WIFI_MODE_AP;
+    esp_wifi_get_mode(&mode);
+    status = esp_wifi_set_mode(mode == WIFI_MODE_STA ? WIFI_MODE_APSTA : WIFI_MODE_AP);
+    SF_CHECK_ERR_GOTO(ESP_LOGE, TAG, status, FAIL, "Set AP mode: %d", status);
+
+    status = esp_wifi_set_config(WIFI_IF_AP, &ap_config);
+    SF_CHECK_ERR_GOTO(ESP_LOGE, TAG, status, FAIL, "Set AP config: %d", status);
+
+    /* Start WiFi; safe to call even if already started (returns error, no-op). */
+    esp_wifi_start();
+
+    ESP_LOGI(TAG, "SoftAP started: SSID=%s", ssid);
+    return SF_OK;
+
+FAIL:
+    return SF_FAIL;
+}
+
+sf_err_t sf_wifi_ap_stop(void)
+{
+    esp_err_t status = esp_wifi_set_mode(WIFI_MODE_STA);
+    SF_CHECK_ERR_RETURN_FAIL(ESP_LOGE, TAG, status, "Set STA mode: %d", status);
+    ESP_LOGI(TAG, "SoftAP stopped.");
+    return SF_OK;
 }
 
 sf_err_t sf_wifi_stop(void)
 {
-    esp_err_t status = ESP_FAIL; 
-
-    status = esp_wifi_stop();
+    if (s_reconnect_timer) {
+        esp_timer_stop(s_reconnect_timer);
+    }
+    esp_err_t status = esp_wifi_stop();
     SF_CHECK_ERR_RETURN_FAIL(ESP_LOGI, TAG, status, "Stop wifi status: %d", status);
-
-    ESP_LOGI(TAG, "wifi_stopped.");
+    ESP_LOGI(TAG, "WiFi stopped.");
     return SF_OK;
+}
+
+/* Deprecated wrapper — removed in commit 5 when sf_watering switches to
+ * sf_wifi_prov_init(). Kconfig entries removed at the same time. */
+sf_err_t sf_wifi_init(void)
+{
+    sf_err_t status = sf_wifi_driver_init();
+    if (status != SF_OK) {
+        return SF_FAIL;
+    }
+    sf_wifi_conn_status_t result = sf_wifi_connect(CONFIG_SIM_FLOW_WIFI_SSID,
+                                                   CONFIG_SIM_FLOW_WIFI_PASSWORD);
+    return (result == SF_WIFI_CONN_OK) ? SF_OK : SF_FAIL;
 }

--- a/components/sf_wifi/sf_wifi.h
+++ b/components/sf_wifi/sf_wifi.h
@@ -1,11 +1,47 @@
+#pragma once
 
+#include "esp_event.h"
 #include "sf_err.h"
 
-#define SF_WIFI_CONFIG_MAXIMUM_RETRY 5
+typedef enum {
+    SF_WIFI_CONN_OK = 0,
+    SF_WIFI_CONN_AUTH_FAIL,  /* WIFI_REASON_AUTH_FAIL (202) only              */
+    SF_WIFI_CONN_NO_AP,      /* SSID not found, AP unreachable, or transient  */
+    SF_WIFI_CONN_FAIL,       /* unexpected failure                            */
+} sf_wifi_conn_status_t;
 
+/* Events posted to the default event loop after sf_wifi_connect() returns.
+ * Suppressed during the blocking initial connect — subscribe after
+ * sf_wifi_prov_init() (which creates the loop) returns. */
+ESP_EVENT_DECLARE_BASE(SF_WIFI_EVENT);
 
+typedef enum {
+    SF_WIFI_EVENT_CONNECTED = 0, /* STA got IP — perpetual phase only            */
+    SF_WIFI_EVENT_DISCONNECTED,  /* STA disconnected — perpetual phase only       */
+    SF_WIFI_EVENT_AUTH_FAIL,     /* auth fail in perpetual reconnect — stop retry */
+} sf_wifi_event_id_t;
 
-sf_err_t sf_wifi_init(void);
+/* One-time stack init: netif, event loop, STA netif, esp_wifi_init, event
+ * handlers, reconnect timer. Guarded — safe to call again (no-op). */
+sf_err_t sf_wifi_driver_init(void);
 
+/* Blocking STA connect. WIFI_REASON_AUTH_FAIL (202): 0 retries, returns
+ * immediately. All other failures: up to 5 retries before returning.
+ * After returning, the perpetual reconnect handler takes over for NO_AP. */
+sf_wifi_conn_status_t sf_wifi_connect(const char *ssid, const char *password);
 
+/* Switch to APSTA, create AP netif (once, guarded), configure and start AP.
+ * Only sf_wifi_prov may call this — never touch esp_wifi_* directly. */
+sf_err_t sf_wifi_ap_start(const char *ssid);
+
+/* Stop the AP, switch back to STA-only mode. */
+sf_err_t sf_wifi_ap_stop(void);
+
+/* Stop the WiFi driver. Cancels any pending reconnect timer.
+ * After this call, sf_wifi_connect() or sf_wifi_ap_start() may be called
+ * again to restart. */
 sf_err_t sf_wifi_stop(void);
+
+/* Deprecated — use sf_wifi_prov_init() instead. Kept for build compatibility
+ * until sf_watering is updated in commit 5. */
+sf_err_t sf_wifi_init(void);


### PR DESCRIPTION
- Replace sf_wifi_init() with sf_wifi_driver_init() (one-time stack init, idempotent) and sf_wifi_connect(ssid, password) (runtime credentials, no Kconfig dependency)
- Add exponential-backoff reconnect timer (esp_timer, task context) for the perpetual phase after initial connect
- Add sf_wifi_ap_start / sf_wifi_ap_stop for APSTA provisioning mode
- Post SF_WIFI_EVENT (CONNECTED / DISCONNECTED / AUTH_FAIL) to default event loop in perpetual phase so callers avoid direct WIFI_EVENT polling
- Distinguish AUTH_FAIL (definitive, 0 retries) from NO_AP (transient, up to 5 retries) in sf_wifi_conn_status_t return value
- Keep deprecated sf_wifi_init() shim for build compatibility until sf_watering is migrated in a follow-up commit